### PR TITLE
Use the same version of Bandit throughout the `pre-commit` config file

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -132,7 +132,7 @@ repos:
           - --config=.bandit.yml
   # Run bandit on everything but the tests directory
   - repo: https://github.com/PyCQA/bandit
-    rev: 1.7.4
+    rev: 1.7.7
     hooks:
       - id: bandit
         name: bandit (everything but the tests directory)


### PR DESCRIPTION
## 🗣 Description ##

This pull request updates the `pre-commit` configuration file to use the same version of the Python package `bandit` throughout.

## 💭 Motivation and context ##

It doesn't make sense to run Bandit twice with different versions.

## 🧪 Testing ##

All automated tests pass.  I also verified that [my Emacs code to install dependencies from `pre-commit`](https://github.com/jsf9k/.dotfiles/blob/master/emacs/dot-emacs.d/jsf9k.el) now functions as expected; previously, it was failing because two different versions of the `bandit` package were being requested.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.