### PR TITLE
Get rid of Docker warnings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG PY_VERSION=3.9
 
-FROM amazon/aws-lambda-python:$PY_VERSION as install-stage
+FROM amazon/aws-lambda-python:$PY_VERSION AS install-stage
 
 # Declare it a second time so it's brought into this scope.
 ARG PY_VERSION=3.9
@@ -25,7 +25,7 @@ COPY src/py$PY_VERSION/ .
 # underlying pip calls.
 RUN pipenv sync --system --extra-pip-args="--no-cache-dir --target ${LAMBDA_TASK_ROOT}"
 
-FROM amazon/aws-lambda-python:$PY_VERSION as build-stage
+FROM amazon/aws-lambda-python:$PY_VERSION AS build-stage
 
 ###
 # For a list of pre-defined annotation keys and value types see:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,4 @@
 ---
-version: "3.2"
-
 services:
   build_deployment_package:
     build: .


### PR DESCRIPTION
## 🗣 Description ##

This pull request gets rid of one warning from `docker compose` and two warnings from `docker build`.

## 💭 Motivation and context ##

- The `docker-compose` warning is due to the fact that the `version` key has been deprecated in Docker composition files.
- The `docker` warnings are both due to the fact that in `Dockerfile` the word `AS` should be uppercase in `FROM...AS...` lines.

Code without warnings is cleaner code.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.