### PR TITLE
Pull AWS Lambda Docker images from AWS' public ECR

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 #
 # Official Docker images are in the form library/<app> while
 # non-official images are in the form <user>/<app>.
-FROM docker.io/amazon/aws-lambda-python:3.9 AS install-stage
+FROM public.ecr.aws/lambda/python:3.9 AS install-stage
 
 # Install the Python packages necessary to install the Lambda dependencies.
 RUN python3 -m pip install --no-cache-dir \
@@ -29,7 +29,7 @@ RUN pipenv sync --system --extra-pip-args="--no-cache-dir --target ${LAMBDA_TASK
 #
 # Official Docker images are in the form library/<app> while
 # non-official images are in the form <user>/<app>.
-FROM docker.io/amazon/aws-lambda-python:3.9 AS build-stage
+FROM public.ecr.aws/lambda/python:3.9 AS build-stage
 
 ###
 # For a list of pre-defined annotation keys and value types see:


### PR DESCRIPTION
## 🗣 Description ##

This pull request updates the `Dockerfile` to pull the AWS Lambda Docker images from AWS' public ECR.

## 💭 Motivation and context ##

Since the images are created by AWS, this just makes more sense. Also, the images for the latest Python runtime (3.14) are not on Docker Hub for some reason.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.